### PR TITLE
Fix pour watchOS et Xcode 13

### DIFF
--- a/Classes/Internal/Data+HexEncodedString.swift
+++ b/Classes/Internal/Data+HexEncodedString.swift
@@ -13,6 +13,8 @@ limitations under the License.
  
 */
 
+import Foundation
+
 extension Data {
     func hexEncodedString() -> String {
         return map { String(format: "%02hhx", $0) }.joined()

--- a/Classes/Public/ActiveLookSDK.swift
+++ b/Classes/Public/ActiveLookSDK.swift
@@ -152,7 +152,7 @@ public class ActiveLookSDK {
                 return
             }
             
-            print("central manager did disconnect to glasses \(discoveredGlasses.name)")
+            print("central manager did connect to glasses \(discoveredGlasses.name)")
 
             let glasses = Glasses(discoveredGlasses: discoveredGlasses)
             let glassesInitializer = GlassesInitializer(glasses: glasses)
@@ -177,7 +177,7 @@ public class ActiveLookSDK {
                 return
             }
 
-            print("central manager did disconnect from glasses \(glasses.name)")
+            print("central manager did disconnect from glasses \(glasses.name) :  \(error?.localizedDescription)")
 
             glasses.disconnectionCallback?()
             glasses.disconnectionCallback = nil

--- a/Classes/Public/ActiveLookSDK.swift
+++ b/Classes/Public/ActiveLookSDK.swift
@@ -135,11 +135,6 @@ public class ActiveLookSDK {
                 print("ignoring non ActiveLook peripheral")
                 return
             }
-            
-            guard parent?.discoveredGlasses(fromPeripheral: peripheral) == nil else {
-                print("glasses already discovered")
-                return
-            }
 
             let discoveredGlasses = DiscoveredGlasses(peripheral: peripheral, centralManager: central, advertisementData: advertisementData)
             parent?.discoveredGlassesArray.append(discoveredGlasses)


### PR DESCRIPTION
- Ajout d'un import nécessaire au build sur Xcode 13
- Quelques fix sur les print / logs
- J'ai enlevé la condition qui empêche l'affichage d'un périphérique "déjà détecté". Ca me posait des problèmes dans la façon dont je gère la découverte / scan dans mon app, mais si il y a une vraie raison derrière et que ça vous bloque sur votre app mobile, on peut en discuter.