### PR TITLE
Fixed crash on trying send bytes after unpair

### DIFF
--- a/Sources/Classes/Public/ActiveLookSDK.swift
+++ b/Sources/Classes/Public/ActiveLookSDK.swift
@@ -432,7 +432,8 @@ public class ActiveLookSDK {
 
         guard let discoveredGlasses = discoveredGlasses(fromPeripheral: glasses.peripheral)
         else {
-            fatalError("discoveredGlasses not found")
+            print("discoveredGlasses not found")
+            return
         }
 
         updater?.update(
@@ -495,7 +496,8 @@ public class ActiveLookSDK {
             print("central manager did update state: ", central.state.rawValue)
 
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance")
+                return
             }
 
             if central.state == .poweredOff {
@@ -544,7 +546,8 @@ public class ActiveLookSDK {
                                    rssi RSSI: NSNumber)
         {
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance")
+                return
             }
             guard parent.peripheralIsActiveLookGlasses(peripheral: peripheral,
                                                        advertisementData: advertisementData)
@@ -572,7 +575,8 @@ public class ActiveLookSDK {
                                    didConnect peripheral: CBPeripheral)
         {
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance")
+                return
             }
 
             guard let discoveredGlasses: DiscoveredGlasses = parent.discoveredGlasses(fromPeripheral: peripheral)
@@ -616,7 +620,8 @@ public class ActiveLookSDK {
                                    error: Error?)
         {
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance")
+                return
             }
 
             guard let glasses = parent.connectedGlasses(fromPeripheral: peripheral) else {

--- a/Sources/Classes/Public/Glasses.swift
+++ b/Sources/Classes/Public/Glasses.swift
@@ -313,9 +313,7 @@ public class Glasses {
     /// sends the bytes queued in commandQueue
     private func sendBytes()
     {
-        if flowControlState != FlowControlState.on { return }
-
-        if rxCharacteristicState == .busy { return }
+        guard flowControlState == .on, let rxCharacteristic, rxCharacteristicState != .busy else { return }
         
         guard let value = commandQueue.dequeue() else {
             if isUpdating {
@@ -340,7 +338,7 @@ public class Glasses {
             }
         }
 
-        peripheral.writeValue(value, for: rxCharacteristic!, type: .withResponse)
+        peripheral.writeValue(value, for: rxCharacteristic, type: .withResponse)
 
         rxCharacteristicState = .busy
     }


### PR DESCRIPTION
<img width="775" height="99" alt="image" src="https://github.com/user-attachments/assets/7fdb4c6c-1b58-45a1-9eff-b5baa611919e" />
**Description:** 
The `sendBytes` method uses force unwrap of `rxCharacteristic`. This leads to a crash if you try to send bytes after disconnecting from the glasses

**Reproduction steps:**
1. Connect to the ActiveLook glasses
2. Unpair the glasses
3. Try to send bytes (For example, read the settings)

**Expected Result:**
If rxCharacteristic is nil, then the `sendBytes` method should not attempt to send bytes

**Actual Result:**
Unhandled exception because rxCharacteristic is nil