### PR TITLE
Fix watchOS compatibility crashes and fatalError paths

### DIFF
--- a/Sources/Classes/Internal/GlassesInitializer.swift
+++ b/Sources/Classes/Internal/GlassesInitializer.swift
@@ -148,12 +148,14 @@ internal class GlassesInitializer: NSObject, CBPeripheralDelegate {
                                              CBUUID.ActiveLookCommandsInterfaceService])
 
         // We're 'polling', or checking regularly that we've received all needed information about the glasses
-        initPollTimer = Timer.scheduledTimer(withTimeInterval: initPollInterval, repeats: true) { (timer) in
+        // Added to .common mode so the timer fires on watchOS where the run loop may be in a non-default mode
+        initPollTimer = Timer(timeInterval: initPollInterval, repeats: true) { (timer) in
             if self.isReady() {
                 self.isDone()
                 timer.invalidate()
             }
         }
+        RunLoop.current.add(initPollTimer!, forMode: .common)
 
         // We're failing after an arbitrary timeout duration
         /*initTimeoutTimer = Timer.scheduledTimer(withTimeInterval: initTimeoutDuration, repeats: false) { _ in

--- a/Sources/Classes/Internal/GlassesInitializer.swift
+++ b/Sources/Classes/Internal/GlassesInitializer.swift
@@ -62,7 +62,8 @@ internal class GlassesInitializer: NSObject, CBPeripheralDelegate {
         super.init()
         
         guard let sdk = try? ActiveLookSDK.shared() else {
-            fatalError(String(format: "SDK Singleton NOT AVAILABLE @  %i", #line))
+            print("GlassesInitializer: SDK singleton not available")
+            return
         }
 
         updateParameters = sdk.updateParameters

--- a/Sources/Classes/Internal/GlassesUpdater/FirmwareUpdater.swift
+++ b/Sources/Classes/Internal/GlassesUpdater/FirmwareUpdater.swift
@@ -94,7 +94,8 @@ public final class FirmwareUpdater: NSObject {
         self.errorClosure = errorClosure
 
         guard let sdk = try? ActiveLookSDK.shared() else {
-            fatalError(String(format: "Cannot retrieve SDK Singleton @ ", #line))
+            print("FirmwareUpdater: SDK singleton not available")
+            return
         }
 
         self.sdk = sdk
@@ -298,7 +299,8 @@ public final class FirmwareUpdater: NSObject {
         guard let characteristic = spotaCharacteristics.first(
             where: { $0.uuid == CBUUID.SPOTA_SERV_STATUS_UUID })
         else {
-            fatalError("SPOTA_SERV_STATUS_UUID NOT RETRIEVED")
+            failed(with: GlassesUpdateError.firmwareUpdater(message: "SPOTA_SERV_STATUS_UUID not retrieved"))
+            return
         }
 
         if !characteristic.isNotifying {
@@ -405,7 +407,8 @@ public final class FirmwareUpdater: NSObject {
     private func setPatchLength() {
 
         guard let firmware = firmware else {
-            fatalError(String(format: "FIRMWARE NOT SET @", #line))
+            failed(with: GlassesUpdateError.firmwareUpdater(message: "firmware not set in setPatchLength"))
+            return
         }
 
         if ( blockId < firmware.blocks.count ) {
@@ -443,7 +446,8 @@ public final class FirmwareUpdater: NSObject {
     private func sendBlock() {
 
         guard let firmware = firmware else {
-            fatalError("FIRMWARE NOT SET")
+            failed(with: GlassesUpdateError.firmwareUpdater(message: "firmware not set in sendBlock"))
+            return
         }
 
         if ( blockId < firmware.blocks.count ) {
@@ -538,7 +542,8 @@ extension FirmwareUpdater: CBPeripheralDelegate
                            didDiscoverServices error: Error?)
     {
         guard let services = peripheral.services else {
-            fatalError("NO SERVICES FOUND")
+            failed(with: GlassesUpdateError.firmwareUpdater(message: "no services found on peripheral"))
+            return
         }
         
         if let activelookCommandsService = services.first(where: {$0.uuid == CBUUID.ActiveLookCommandsInterfaceService}) {
@@ -547,7 +552,8 @@ extension FirmwareUpdater: CBPeripheralDelegate
         }
 
         guard let spotaService = services.first(where: {$0.uuid == CBUUID.SpotaService}) else {
-            fatalError("NO SPOTA SERVICE FOUND")
+            failed(with: GlassesUpdateError.firmwareUpdater(message: "SPOTA service not found"))
+            return
         }
 
         peripheral.discoverCharacteristics(nil, for: spotaService)
@@ -631,7 +637,7 @@ extension FirmwareUpdater: CBPeripheralDelegate
 
         case CBUUID.SPOTA_MEM_DEV_UUID :
             guard let value = characteristic.value else {
-                fatalError("SPOTA_MEM_DEV_UUID is nil")
+                return
             }
 
             if (value.count >= 4 && value[0] == 0x00 && value[1] == 0x00
@@ -669,7 +675,8 @@ extension FirmwareUpdater: CBPeripheralDelegate
             } else {
                 guard let charac = spotaCharacteristics.first(
                     where: { $0.uuid == CBUUID.SPOTA_MEM_DEV_UUID}) else {
-                        fatalError()
+                        failed(with: GlassesUpdateError.firmwareUpdater(message: "SPOTA_MEM_DEV_UUID not found"))
+                        return
                     }
                 peripheral.writeValue( Data( UInt32( 0xfe000000 ).byteArray ),
                                        for: charac,

--- a/Sources/Classes/Internal/GlassesUpdater/GlassesUpdater.swift
+++ b/Sources/Classes/Internal/GlassesUpdater/GlassesUpdater.swift
@@ -15,7 +15,9 @@
 
 import Foundation
 import CoreBluetooth
+#if canImport(UIKit)
 import UIKit
+#endif
 
 // MARK: - Internal Enumerations
 

--- a/Sources/Classes/Internal/GlassesUpdater/GlassesUpdater.swift
+++ b/Sources/Classes/Internal/GlassesUpdater/GlassesUpdater.swift
@@ -123,7 +123,8 @@ internal class GlassesUpdater {
     {
         guard let sdk = try? ActiveLookSDK.shared()
         else {
-            fatalError("SDK Singleton NOT AVAILABLE")
+            print("GlassesUpdater: SDK singleton not available")
+            return
         }
 
         self.sdk = sdk
@@ -269,7 +270,8 @@ internal class GlassesUpdater {
     private func askUpdateAuthorization(for firmware: Firmware)
     {
         guard let sdkGU = sdk?.updateParameters.createSDKGU(.updatingFw) else {
-            fatalError("cannot create SDKGlassesUpdate from .updatingFW")
+            print("GlassesUpdater: cannot create SDKGlassesUpdate from .updatingFw")
+            return
         }
 
         // the decision is processed via an observer on `self.authorisation`
@@ -397,7 +399,8 @@ internal class GlassesUpdater {
     private func askUpdateAuthorization(for configuration: String)
     {
         guard let sdkGU = sdk?.updateParameters.createSDKGU(.updatingConfig) else {
-            fatalError("cannot create SDKGlassesUpdate from .updatingConfig")
+            print("GlassesUpdater: cannot create SDKGlassesUpdate from .updatingConfig")
+            return
         }
         // the decision is processed via an observer on `self.authorisation`
         self.authorization = Authorization(.configuration(configuration))

--- a/Sources/Classes/Internal/GlassesUpdater/GlassesUpdaterURL.swift
+++ b/Sources/Classes/Internal/GlassesUpdater/GlassesUpdaterURL.swift
@@ -47,7 +47,8 @@ internal final class GlassesUpdaterURL {
         GlassesUpdaterURL._shared = self
 
         guard let sdk = try? ActiveLookSDK.shared() else {
-            fatalError(String(format: "SDK Singleton NOT AVAILABLE @  %i", #line))
+            print("GlassesUpdaterURL: SDK singleton not available")
+            return
         }
 
         self.sdk = sdk
@@ -68,7 +69,7 @@ internal final class GlassesUpdaterURL {
     }
 
 
-    func configurationHistoryURL(for firmwareVersion: FirmwareVersion) -> URL {
+    func configurationHistoryURL(for firmwareVersion: FirmwareVersion) -> URL? {
 
         dlog(message: "",line: #line, function: #function, file: #fileID)
 
@@ -77,16 +78,16 @@ internal final class GlassesUpdaterURL {
     }
 
 
-    func configurationDownloadURL(using apiPathString: String) -> URL {
+    func configurationDownloadURL(using apiPathString: String) -> URL? {
 
         dlog(message: "",line: #line, function: #function, file: #fileID)
-        
+
         softwareClass = .configurations
         return generateDownloadURL(for: apiPathString)
     }
 
 
-    func firmwareHistoryURL(for firmwareVersion: FirmwareVersion) -> URL {
+    func firmwareHistoryURL(for firmwareVersion: FirmwareVersion) -> URL? {
 
         dlog(message: "",line: #line, function: #function, file: #fileID)
 
@@ -95,7 +96,7 @@ internal final class GlassesUpdaterURL {
     }
 
 
-    func firmwareDownloadURL(using apiPathString: String) -> URL {
+    func firmwareDownloadURL(using apiPathString: String) -> URL? {
 
         dlog(message: "",line: #line, function: #function, file: #fileID)
 
@@ -106,14 +107,16 @@ internal final class GlassesUpdaterURL {
 
     // MARK: - Private Methods
 
-    private func generateURL(for firmwareVersion: FirmwareVersion) -> URL
+    private func generateURL(for firmwareVersion: FirmwareVersion) -> URL?
     {
         guard let hardware = sdk?.updateParameters.hardware else {
-            fatalError("NO HARDWARE SET")
+            print("GlassesUpdaterURL: no hardware set")
+            return nil
         }
 
         guard let token = sdk?.updateParameters.token else {
-            fatalError("NO TOKEN SET")
+            print("GlassesUpdaterURL: no token set")
+            return nil
         }
 
         let pathComponents = [
@@ -152,14 +155,16 @@ internal final class GlassesUpdaterURL {
     }
 
     
-    private func generateDownloadURL(for version: String) -> URL
+    private func generateDownloadURL(for version: String) -> URL?
     {
         guard let hardware = sdk?.updateParameters.hardware else {
-            fatalError("NO HARDWARE SET")
+            print("GlassesUpdaterURL: no hardware set")
+            return nil
         }
 
         guard let token = sdk?.updateParameters.token else {
-            fatalError("NO TOKEN SET")
+            print("GlassesUpdaterURL: no token set")
+            return nil
         }
 
         var version = version

--- a/Sources/Classes/Internal/GlassesUpdater/VersionChecker.swift
+++ b/Sources/Classes/Internal/GlassesUpdater/VersionChecker.swift
@@ -57,7 +57,7 @@ internal final class VersionChecker: NSObject {
 
     // MARK: - Private Variables
 
-    private var sdk: ActiveLookSDK
+    private var sdk: ActiveLookSDK?
     private var glasses: Glasses?
     private var peripheral: CBPeripheral?
 
@@ -123,13 +123,14 @@ internal final class VersionChecker: NSObject {
         dlog(message: "",line: #line, function: #function, file: #fileID)
 
         urlGenerator = GlassesUpdaterURL()
-        
+
+        super.init()
+
         guard let sdk = try? ActiveLookSDK.shared() else {
-            fatalError(String(format: "Cannot retrieve SDK Singleton @ ", #line))
+            print("VersionChecker: SDK singleton not available")
+            return
         }
         self.sdk = sdk
-        
-        super.init()
     }
 
 
@@ -172,7 +173,7 @@ internal final class VersionChecker: NSObject {
         // call to retrieve glasses configuration concurrently with remote configuration
         glasses.cfgRead(name: "ALooK", callback: { (config: ConfigurationElementsInfo) in
             let cfgVers = ConfigurationVersion(major: Int(config.version))
-            self.sdk.updateParameters.set(version: cfgVers, for: .device)
+            self.sdk?.updateParameters.set(version: cfgVers, for: .device)
             self.glassesConfigurationVersion = config.version
         })
 
@@ -216,7 +217,10 @@ internal final class VersionChecker: NSObject {
         }
 
         // format URL string
-        let url = urlGenerator.configurationHistoryURL(for: gfw)
+        guard let url = urlGenerator.configurationHistoryURL(for: gfw) else {
+            failed(with: GlassesUpdateError.versionChecker(message: "could not generate configuration history URL"))
+            return
+        }
 
         task = URLSession.shared.dataTask( with: url ) { data, response, error in
             guard error == nil else {
@@ -263,7 +267,7 @@ internal final class VersionChecker: NSObject {
                                                                         major: vers[3],
                                                                         path: apiPath)
                 
-                self.sdk.updateParameters.set(version: self.remoteConfigurationVersion!, for: .remote)
+                self.sdk?.updateParameters.set(version: self.remoteConfigurationVersion!, for: .remote)
             }
         }
 
@@ -290,7 +294,7 @@ internal final class VersionChecker: NSObject {
                 return
             }
 
-            let apiURL = urlGenerator.configurationDownloadURL(using: apiPath)
+            guard let apiURL = urlGenerator.configurationDownloadURL(using: apiPath) else { return }
             result = VersionCheckResult( software: .configurations, status: .needsUpdate(apiURL: apiURL) )
 
         } else {
@@ -322,7 +326,10 @@ internal final class VersionChecker: NSObject {
         }
 
         // format URL string
-        let url = urlGenerator.firmwareHistoryURL(for: gfw)
+        guard let url = urlGenerator.firmwareHistoryURL(for: gfw) else {
+            failed(with: GlassesUpdateError.versionChecker(message: "could not generate firmware history URL"))
+            return
+        }
 
         let task = URLSession.shared.dataTask( with: url ) { data, response, error in
             guard error == nil
@@ -358,7 +365,7 @@ internal final class VersionChecker: NSObject {
                                         extra: "",
                                         path:
                                           GlassesUpdateError.versionCheckerNoUpdateAvailable.localizedDescription)
-                    self.sdk.updateParameters.set(version: self.remoteFWVersion!, for: .remote)
+                    self.sdk?.updateParameters.set(version: self.remoteFWVersion!, for: .remote)
                 }
                 return
             }
@@ -385,7 +392,7 @@ internal final class VersionChecker: NSObject {
                                              patch: vers[2],
                                              extra: "",
                                              path: "\(vers[0]).\(vers[1]).\(vers[2])")
-                self.sdk.updateParameters.set(version: fwVers, for: .remote)
+                self.sdk?.updateParameters.set(version: fwVers, for: .remote)
                 self.remoteFWVersion = fwVers
             }
 
@@ -412,7 +419,7 @@ internal final class VersionChecker: NSObject {
 //                    message: String(format: "remote FW path NOT SET @", #line)))
                 return
             }
-            let apiURL = urlGenerator.firmwareDownloadURL(using: apiPath)
+            guard let apiURL = urlGenerator.firmwareDownloadURL(using: apiPath) else { return }
             result = VersionCheckResult( software: .firmwares, status: .needsUpdate(apiURL: apiURL) )
         } else {
             // up-to-date
@@ -461,7 +468,7 @@ internal final class VersionChecker: NSObject {
                                      patch: patch,
                                      extra: nil, path: nil, error: nil)
 
-        sdk.updateParameters.set(version: fwVers, for: .device)
+        sdk?.updateParameters.set(version: fwVers, for: .device)
 
         glassesFWVersion = fwVers
     }

--- a/Sources/Classes/Internal/ImageConverter.swift
+++ b/Sources/Classes/Internal/ImageConverter.swift
@@ -13,11 +13,14 @@ limitations under the License.
  */
 
 import Foundation
+#if canImport(UIKit)
 import UIKit
+#endif
 #if canImport(Heatshrink)
 import Heatshrink
 #endif
 
+#if canImport(UIKit)
 internal class ImageConverter {
     
     internal func getImageData(img: UIImage, fmt: ImgSaveFmt) -> ImageData{
@@ -199,3 +202,4 @@ internal class ImageConverter {
         return encodedImg
     }
 }
+#endif

--- a/Sources/Classes/Internal/ImageMDP05.swift
+++ b/Sources/Classes/Internal/ImageMDP05.swift
@@ -14,6 +14,7 @@ limitations under the License.
 */
 
 import Foundation
+#if canImport(UIKit)
 import UIKit
 
 internal class ImageMDP05{
@@ -63,3 +64,4 @@ internal class ImageMDP05{
         return encodedImg
     }
 }
+#endif

--- a/Sources/Classes/Internal/UIImage+ActiveLook.swift
+++ b/Sources/Classes/Internal/UIImage+ActiveLook.swift
@@ -13,6 +13,7 @@ limitations under the License.
  */
 
 import Foundation
+#if canImport(UIKit)
 import UIKit
 
 extension UIImage{
@@ -55,3 +56,4 @@ extension UIImage{
         return PixelsArray
     }
 }
+#endif

--- a/Sources/Classes/Public/ActiveLookSDK.swift
+++ b/Sources/Classes/Public/ActiveLookSDK.swift
@@ -432,7 +432,8 @@ public class ActiveLookSDK {
 
         guard let discoveredGlasses = discoveredGlasses(fromPeripheral: glasses.peripheral)
         else {
-            fatalError("discoveredGlasses not found")
+            print("updateInitializedGlasses: discoveredGlasses not found for peripheral \(glasses.peripheral)")
+            return
         }
 
         updater?.update(
@@ -495,7 +496,7 @@ public class ActiveLookSDK {
             print("central manager did update state: ", central.state.rawValue)
 
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance"); return
             }
 
             if central.state == .poweredOff {
@@ -544,7 +545,7 @@ public class ActiveLookSDK {
                                    rssi RSSI: NSNumber)
         {
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance"); return
             }
             guard parent.peripheralIsActiveLookGlasses(peripheral: peripheral,
                                                        advertisementData: advertisementData)
@@ -572,7 +573,7 @@ public class ActiveLookSDK {
                                    didConnect peripheral: CBPeripheral)
         {
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance"); return
             }
 
             guard let discoveredGlasses: DiscoveredGlasses = parent.discoveredGlasses(fromPeripheral: peripheral)
@@ -616,7 +617,7 @@ public class ActiveLookSDK {
                                    error: Error?)
         {
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("cannot retrieve parent instance"); return
             }
 
             guard let glasses = parent.connectedGlasses(fromPeripheral: peripheral) else {

--- a/Sources/Classes/Public/Glasses.swift
+++ b/Sources/Classes/Public/Glasses.swift
@@ -202,7 +202,8 @@ public class Glasses {
         self.peripheral.delegate = self.peripheralDelegate
 
         guard let sdk = try? ActiveLookSDK.shared() else {
-            fatalError("Cannot retrieve SDK Singleton")
+            print("Glasses: SDK singleton not available")
+            return
         }
 
         self.sdk = sdk
@@ -520,7 +521,7 @@ public class Glasses {
     public func compareFirmwareAtLeast(version: String) -> ComparisonResult {
         let version = "v\(version).0b"
         let gVersion = self.getDeviceInformation().firmwareVersion
-        guard let gVersion = gVersion else { fatalError("gVersion not set") }
+        guard let gVersion = gVersion else { return .orderedDescending }
         return version.compare(gVersion, options: .numeric)
     }
     
@@ -1908,7 +1909,8 @@ public class Glasses {
             }
 
             guard let parent = parent else {
-                fatalError("cannot retrieve parent instance")
+                print("Glasses PeripheralDelegate: cannot retrieve parent instance")
+                return
             }
 
             //print("peripheral did update value for characteristic: ", characteristic.uuid)

--- a/Sources/Classes/Public/Glasses.swift
+++ b/Sources/Classes/Public/Glasses.swift
@@ -15,7 +15,9 @@ limitations under the License.
 
 import Foundation
 import CoreBluetooth
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// A representation of connected ActiveLook® glasses.
 ///
@@ -854,6 +856,7 @@ public class Glasses {
         }
     }
     
+    #if canImport(UIKit)
     /// Save an image of the specified width and on a specific format.
     /// - Parameters:
     ///     - id: The id of the image to display
@@ -1102,7 +1105,8 @@ public class Glasses {
             sendCommand(id: .imgStream, withData: chunk) // TODO This will probably cause unhandled overflow if the image is too big
         }
     }
-    
+    #endif
+
     // MARK: - Font commands
     
     /// WARNING: CALLBACK NOT WORKING as of 3.7.4b


### PR DESCRIPTION
This PR improves watchOS compatibility and prevents several SDK-level crashes.

  - Guards UIKit-dependent image APIs with `canImport(UIKit)` so watchOS builds do not reference UIKit-only types.
  - Replaces multiple internal `fatalError` calls with graceful returns, logging, or propagated update errors.
  - Makes updater URL generation nullable and handles missing SDK, hardware, token, or URL state without crashing.
  - Adjusts initialization timer scheduling for watchOS compatibility.

  ## Notes

  The changes touch the SDK initialization, glasses updater flow, firmware/version checking, and UIKit-backed image
  helpers.

  ## Validation

  Please validate by building the iOS and watchOS targets.